### PR TITLE
Add caching interface and class; update project structure

### DIFF
--- a/Moodify.Shared/Caching/ICacheManager.cs
+++ b/Moodify.Shared/Caching/ICacheManager.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moodify.Shared.Caching
+{
+	public interface ICacheManager
+	{
+	}
+}

--- a/Moodify.Shared/Caching/MemoryCacheManager.cs
+++ b/Moodify.Shared/Caching/MemoryCacheManager.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moodify.Shared.Caching
+{
+	public class MemoryCacheManager:ICacheManager
+	{
+	}
+}

--- a/Moodify.Shared/Moodify.Shared.csproj
+++ b/Moodify.Shared/Moodify.Shared.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Caching\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Removed the `<Folder Include="Caching\" />` entry from the `Moodify.Shared.csproj` file, simplifying the project structure.

Added a new `ICacheManager` interface and a `MemoryCacheManager` class under the `Moodify.Shared.Caching` namespace. Both are placeholders with no implemented functionality yet.